### PR TITLE
Added proper command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Usage
 #### flags
 ```
 flag | default | help
+-name="": Telegram username of the bot
 -c="./config.yml": path for ritalobot config
 -conn="tcp": type of connection and/or ip of redis database
 -p=6379: port number of redis database

--- a/bot.go
+++ b/bot.go
@@ -38,16 +38,26 @@ func sendCommand(method, token string, params url.Values) ([]byte, error) {
 	return json, nil
 }
 
-func (bot *Bot) Commands(command string, chat int) {
+func (bot *Bot) Commands(input string, chat int) {
 	markov := Markov{20}
-	word := strings.Split(command, " ")
+	word := strings.Split(input, " ")
 
 	seed := strings.Join(word[1:], " ") // Removes the initial command
 
-	if word[0] == "/chobot" && len(word) >= 2 {
+	commandParts := strings.Split(word[0], "@")
+	var command = commandParts[0]
+
+	if len(commandParts) > 1 {
+		var botName = commandParts[1]
+		if (botName != name) { // Bail out if the command was directed at another bot
+			return
+		}
+	}
+
+	if command == "/chobot" && len(word) >= 2 {
 		text := markov.Generate(seed, bot.Connection)
 		bot.Say(text, chat)
-	} else if word[0] == "/chosource" {
+	} else if command == "/chosource" {
 		text := fmt.Sprintf("Author: %v \nSource: %v",
 			"@blackdev1l",
 			"https://github.com/blackdev1l/ritalobot")

--- a/bot.go
+++ b/bot.go
@@ -97,15 +97,15 @@ func (bot Bot) GetUpdates() []Result {
 		log.Println(err)
 	}
 
-	var updatesRecieved Response
-	json.Unmarshal(resp, &updatesRecieved)
+	var updatesReceived Response
+	json.Unmarshal(resp, &updatesReceived)
 
-	if !updatesRecieved.Ok {
-		err = fmt.Errorf("chobot: %s\n", updatesRecieved.Description)
+	if !updatesReceived.Ok {
+		err = fmt.Errorf("chobot: %s\n", updatesReceived.Description)
 		return nil
 	}
 
-	var updates = updatesRecieved.Result
+	var updates = updatesReceived.Result
 	if len(updates) != 0 {
 
 		updateID := updates[len(updates)-1].Update_id + 1
@@ -126,7 +126,7 @@ func (bot Bot) Say(text string, chat int) (bool, error) {
 		return true, nil
 	}
 
-	var responseRecieved struct {
+	var responseReceived struct {
 		Ok          bool
 		Description string
 	}
@@ -137,16 +137,16 @@ func (bot Bot) Say(text string, chat int) (bool, error) {
 	params.Set("text", text)
 	resp, err := sendCommand("sendMessage", token, params)
 
-	err = json.Unmarshal(resp, &responseRecieved)
+	err = json.Unmarshal(resp, &responseReceived)
 	if err != nil {
 		return false, err
 	}
 
-	if !responseRecieved.Ok {
-		return false, fmt.Errorf("chobot: %s\n", responseRecieved.Description)
+	if !responseReceived.Ok {
+		return false, fmt.Errorf("chobot: %s\n", responseReceived.Description)
 	}
 
-	return responseRecieved.Ok, nil
+	return responseReceived.Ok, nil
 }
 
 func (bot Bot) Listen() {

--- a/bot.go
+++ b/bot.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+var rate int
+
 func sendCommand(method, token string, params url.Values) ([]byte, error) {
 	url := fmt.Sprintf("https://api.telegram.org/bot%s/%s?%s",
 		token, method, params.Encode())
@@ -66,8 +68,8 @@ func (bot *Bot) Commands(input string, author string) string {
 		if err != nil || n < 0 || n > 100 {
 			return "Use a number between 0 and 100."
 		} else {
-			bot.Chance = n
-			log.Printf("Bot rate: %v\n", bot.Chance)
+			rate = n
+			log.Printf("Bot rate: %v\n", rate)
 			return "Rate set"
 		}
 	} else if command == "/chosource" {
@@ -119,7 +121,7 @@ func (bot Bot) Listen() {
 	var err error
 
 	rand.Seed(time.Now().UnixNano())
-	bot.Chance = chance
+	rate = chance
 
 	tmp := ":" + strconv.Itoa(port)
 	bot.Connection, err = redis.Dial(connection, tmp)
@@ -128,7 +130,7 @@ func (bot Bot) Listen() {
 		log.Fatal(err)
 	}
 	fmt.Printf("redis connection: %v | port is %v\n", connection, port)
-	fmt.Printf("chance rate %v%!\n", bot.Chance)
+	fmt.Printf("chance rate %v%!\n", rate)
 
 	bot.Poll()
 
@@ -197,7 +199,7 @@ func fetchAuthor(item Result) User {
 func process(text string, inline bool, author User, markov Markov, bot Bot) string {
 	if strings.HasPrefix(text, "/cho") {
 		return bot.Commands(text, author.Username)
-	} else if inline || (rand.Intn(100) <= bot.Chance) {
+	} else if inline || (rand.Intn(100) <= rate && rate != 0) {
 		var seed string
 		if (inline) {
 			seed = text

--- a/bot.go
+++ b/bot.go
@@ -95,34 +95,31 @@ func (bot Bot) GetUpdates() []Result {
 	resp, err := sendCommand("getUpdates", token, params)
 	if err != nil {
 		log.Println(err)
+		return nil
 	}
 
 	var updatesReceived Response
 	json.Unmarshal(resp, &updatesReceived)
 
 	if !updatesReceived.Ok {
-		err = fmt.Errorf("chobot: %s\n", updatesReceived.Description)
+		log.Println("updatesReceived not OK")
+		log.Println(updatesReceived.Description)
 		return nil
 	}
 
-	var updates = updatesReceived.Result
-	if len(updates) != 0 {
+	updates := updatesReceived.Result
 
+	if len(updates) != 0 {
 		updateID := updates[len(updates)-1].Update_id + 1
 		bot.Connection.Do("SET", "update_id", updateID)
-
-		return updates
-
 	}
-	return nil
+
+	return updates
 }
 
 func (bot Bot) Say(text string, chat int) (bool, error) {
 
-	if (strings.HasPrefix(text, "!kickme")) {
-		return true, nil
-	}
-	if (strings.HasPrefix(text, "/AttivaTelegramPremium")) {
+	if strings.HasPrefix(text, "!kickme") || strings.HasPrefix(text, "/AttivaTelegramPremium") {
 		return true, nil
 	}
 

--- a/bot.go
+++ b/bot.go
@@ -167,9 +167,7 @@ func (bot Bot) Poll() {
 					updates[0].Message.Chat.Id)
 
 			} else if rand.Intn(100) <= bot.Chance {
-				in_text := updates[len(updates)-1].Message.Text
-				parts := strings.Split(in_text, " ")
-				seed := parts[0] // Seed the chain with the first word only
+				seed, _ := redis.String(bot.Connection.Do("RANDOMKEY"))
 
 				chat := updates[len(updates)-1].Message.Chat.Id
 				out_text := markov.Generate(seed, bot.Connection)

--- a/bot.go
+++ b/bot.go
@@ -151,9 +151,17 @@ func (bot Bot) Poll() {
 				text := fetchText(update)
 				author := fetchAuthor(update)
 				markov.StoreUpdate(text, bot.Connection)
-				response := process(text, isInline(update), author, markov, bot)
 
-				if response != "" {
+				i := 0
+				var response string
+				log.Println(text)
+				for i == 0 || (strings.Trim(response, " \t") == strings.Trim(text, " \t") && i < 5) {
+					response = process(text, isInline(update), author, markov, bot)
+					i++
+				}
+
+				if response != "" && i != 5 {
+					log.Println("Done")
 					if update.Message.Text != "" {
 						limiter.Wait()
 						bot.Say(response, update.Message.Chat.Id)

--- a/bot.go
+++ b/bot.go
@@ -57,6 +57,15 @@ func (bot *Bot) Commands(input string, chat int) {
 	if command == "/chobot" && len(word) >= 2 {
 		text := markov.Generate(seed, bot.Connection)
 		bot.Say(text, chat)
+	} else if word[0] == "/chorate" && len(word) >= 2 {
+		n, err := strconv.Atoi(word[1])
+		if err != nil || n <= 0 || n > 100 {
+			bot.Say("Use a number between 1 and 100.", chat)
+		} else {
+			bot.Chance = n
+			log.Printf("Bot rate: %v\n", bot.Chance)
+			bot.Say("Rate set", chat)
+		}
 	} else if command == "/chosource" {
 		text := fmt.Sprintf("Author: %v \nSource: %v",
 			"@blackdev1l",

--- a/example.yml
+++ b/example.yml
@@ -2,3 +2,4 @@ token: abcdefgh1234567890
 connection: tcp
 chance: 20
 port: 6379
+name: ritalobot

--- a/example.yml
+++ b/example.yml
@@ -3,3 +3,4 @@ connection: tcp
 chance: 20
 port: 6379
 name: ritalobot
+author: CapacitorSet

--- a/markov.go
+++ b/markov.go
@@ -14,7 +14,7 @@ type Markov struct {
 func (m Markov) StoreUpdates(updates []Result, connection redis.Conn) {
 	for _, update := range updates {
 		message := update.Message.Text
-		if message != "" && !strings.HasPrefix(message, "/") {
+		if message != "" && !strings.HasPrefix(message, "/") && len(message) < 300 {
 			m.Store(update.Message.Text, connection)
 		}
 	}

--- a/markov.go
+++ b/markov.go
@@ -11,12 +11,9 @@ type Markov struct {
 	length int
 }
 
-func (m Markov) StoreUpdates(updates []Result, connection redis.Conn) {
-	for _, update := range updates {
-		message := update.Message.Text
-		if message != "" && !strings.HasPrefix(message, "/") && len(message) < 300 {
-			m.Store(update.Message.Text, connection)
-		}
+func (m Markov) StoreUpdate(message string, connection redis.Conn) {
+	if message != "" && !strings.HasPrefix(message, "/") && len(message) < 300 {
+		m.Store(message, connection)
 	}
 }
 

--- a/response.go
+++ b/response.go
@@ -7,18 +7,25 @@ type Response struct {
 }
 
 type Result struct {
-	Update_id int     `json:"update_id"`
-	Message   Message `json:"message"`
+	Update_id	int		`json:"update_id"`
+	Message		Message	`json:"message"`
+	Inline		Inline 	`json:"inline_query"`
 }
 
 type Message struct {
-	Message_id int    `json:"message_id"`
-	From       From   `json:"from"`
-	Chat       Chat   `json:"chat"`
-	Text       string `json:"text"`
+	Message_id	int    `json:"message_id"`
+	From		User   `json:"from"`
+	Chat		Chat   `json:"chat"`
+	Text		string `json:"text"`
 }
 
-type From struct {
+type Inline struct {
+	Id			string	`json:"id"`
+	From		User	`json:"from"`
+	Text		string	`json:"query"`
+}
+
+type User struct {
 	Id       int
 	Username string
 }

--- a/ritalobot.go
+++ b/ritalobot.go
@@ -11,18 +11,20 @@ import (
 )
 
 var (
-	port       int
-	token      string
-	connection string
-	configPath string
-	chance     int
+	name		string
+	port		int
+	token 		string
+	connection	string
+	configPath	string
+	chance		int
 )
 
 type Config struct {
-	Token      string `yaml:"token"`
-	Chance     int    `yaml: "chance"`
-	Connection string `yaml:"connection"`
-	Port       int    `yaml:"port"`
+	Token		string	`yaml:"token"`
+	Chance		int		`yaml:"chance"`
+	Connection	string	`yaml:"connection"`
+	Name		string	`yaml:"name"`
+	Port		int		`yaml:"port"`
 }
 
 func printLogo() {
@@ -52,6 +54,7 @@ func readConfig(configPath string) int {
 	chance = c.Chance
 	connection = c.Connection
 	port = c.Port
+	name = c.Name
 	return 0
 }
 

--- a/ritalobot.go
+++ b/ritalobot.go
@@ -17,6 +17,7 @@ var (
 	connection	string
 	configPath	string
 	chance		int
+	admin		string
 )
 
 type Config struct {
@@ -25,6 +26,7 @@ type Config struct {
 	Connection	string	`yaml:"connection"`
 	Name		string	`yaml:"name"`
 	Port		int		`yaml:"port"`
+	Admin		string	`yaml:"admin"`
 }
 
 func printLogo() {
@@ -55,6 +57,7 @@ func readConfig(configPath string) int {
 	connection = c.Connection
 	port = c.Port
 	name = c.Name
+	admin = c.Admin
 	return 0
 }
 

--- a/ritalobot.go
+++ b/ritalobot.go
@@ -62,6 +62,7 @@ func main() {
 
 	printLogo()
 
+	flag.StringVar(&name, "name", "", "Telegram username of the bot")
 	flag.StringVar(&token, "token", "", "authentication token for the telegram bot")
 	flag.StringVar(&connection, "conn", "tcp", "type of connection and/or ip of redis database")
 	flag.IntVar(&port, "p", 6379, "port number of redis database")


### PR DESCRIPTION
The bot now parses commands correctly, so that it can discard commands explicitly directed at other bots (i.e. `/chobot@anotherbot`) and support `/chobot@ritalobot seed`.
